### PR TITLE
perf: adding buffer pool

### DIFF
--- a/source/Client/SimpleWebClient.cs
+++ b/source/Client/SimpleWebClient.cs
@@ -26,14 +26,17 @@ namespace Mirror.SimpleWeb
 #endif
         }
 
-
         readonly int maxMessagesPerTick;
+        protected readonly int maxMessageSize;
         protected readonly ConcurrentQueue<Message> receiveQueue = new ConcurrentQueue<Message>();
+        protected readonly BufferPool bufferPool;
+
         protected ClientState state;
 
-        protected SimpleWebClient(int maxMessagesPerTick)
+        protected SimpleWebClient(int maxMessageSize, int maxMessagesPerTick)
         {
             this.maxMessagesPerTick = maxMessagesPerTick;
+            bufferPool = new BufferPool(5, 20, maxMessageSize);
         }
         public ClientState ConnectionState => state;
 

--- a/source/Client/SimpleWebClient.cs
+++ b/source/Client/SimpleWebClient.cs
@@ -35,6 +35,7 @@ namespace Mirror.SimpleWeb
 
         protected SimpleWebClient(int maxMessageSize, int maxMessagesPerTick)
         {
+            this.maxMessageSize = maxMessageSize;
             this.maxMessagesPerTick = maxMessagesPerTick;
             bufferPool = new BufferPool(5, 20, maxMessageSize);
         }

--- a/source/Client/StandAlone/WebSocketClientStandAlone.cs
+++ b/source/Client/StandAlone/WebSocketClientStandAlone.cs
@@ -130,6 +130,7 @@ namespace Mirror.SimpleWeb
 
         public override void Send(ArraySegment<byte> source)
         {
+            // todo remove allocation
             byte[] buffer = new byte[source.Count];
             Array.Copy(source.Array, source.Offset, buffer, 0, source.Count);
             ArraySegment<byte> copy = new ArraySegment<byte>(buffer);

--- a/source/Client/Webgl/WebSocketClientWebGl.cs
+++ b/source/Client/Webgl/WebSocketClientWebGl.cs
@@ -10,12 +10,10 @@ namespace Mirror.SimpleWeb
     {
         static readonly Dictionary<int, WebSocketClientWebGl> instances = new Dictionary<int, WebSocketClientWebGl>();
 
-        readonly int maxMessageSize;
         public int index;
 
-        internal WebSocketClientWebGl(int maxMessageSize, int maxMessagesPerTick) : base(maxMessagesPerTick)
+        internal WebSocketClientWebGl(int maxMessageSize, int maxMessagesPerTick) : base(maxMessageSize, maxMessagesPerTick)
         {
-            this.maxMessageSize = maxMessageSize;
 #if !UNITY_WEBGL || UNITY_EDITOR
             throw new NotSupportedException();
 #endif

--- a/source/Common/BufferPool.cs
+++ b/source/Common/BufferPool.cs
@@ -179,7 +179,7 @@ namespace Mirror.SimpleWeb
 
             for (int i = 0; i < bucketCount; i++)
             {
-                if (size < buckets[i].arraySize)
+                if (size <= buckets[i].arraySize)
                 {
                     return buckets[i].Take();
                 }

--- a/source/Common/BufferPool.cs
+++ b/source/Common/BufferPool.cs
@@ -45,7 +45,7 @@ namespace Mirror.SimpleWeb
 
         public void CopyTo(byte[] target, int offset)
         {
-            if (Length > target.Length) throw new ArgumentException($"{nameof(Length)} was greater than {nameof(target)}.length", nameof(target));
+            if (Length > (target.Length + offset)) throw new ArgumentException($"{nameof(Length)} was greater than {nameof(target)}.length", nameof(target));
 
             //todo check if Buffer.BlockCopy is faster
             Array.Copy(array, 0, target, offset, Length);

--- a/source/Common/BufferPool.cs
+++ b/source/Common/BufferPool.cs
@@ -95,17 +95,22 @@ namespace Mirror.SimpleWeb
     }
 
     /// <summary>
-    /// Collection of different sized buffers 
+    /// Collection of different sized buffers
     /// </summary>
     /// <remarks>
-    /// Problem:
-    /// * need cached byte[] so that new ones arn't created each time.
-    /// * arrays sent are multiple different sizes
-    /// * some message might be bit so need buffers to cover that size
-    /// * most messages will be small compared to max message size
-    /// Solution:
-    /// * create multiple groups of buffers covering the range of allowed sizes
-    /// * split range using math.log so that there are more size groups for small buffers
+    /// <para>
+    /// Problem: <br/>
+    ///     * Need to cached byte[] so that new ones arn't created each time <br/>
+    ///     * Arrays sent are multiple different sizes <br/>
+    ///     * Some message might be big so need buffers to cover that size <br/>
+    ///     * Most messages will be small compared to max message size <br/>
+    /// </para>
+    /// <br/>
+    /// <para>
+    /// Solution: <br/>
+    ///     * Create multiple groups of buffers covering the range of allowed sizes <br/>
+    ///     * Split range exponentially (using math.log) so that there are more groups for small buffers <br/>
+    /// </para>
     /// </remarks>
     public class BufferPool
     {

--- a/source/Common/BufferPool.cs
+++ b/source/Common/BufferPool.cs
@@ -55,6 +55,7 @@ namespace Mirror.SimpleWeb
         {
             CopyFrom(segment.Array, segment.Offset, segment.Count);
         }
+
         public void CopyFrom(byte[] source, int offset, int length)
         {
             if (length > array.Length) throw new ArgumentException($"{nameof(length)} was greater than {nameof(array)}.length", nameof(length));

--- a/source/Common/BufferPool.cs
+++ b/source/Common/BufferPool.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Concurrent;
+using UnityEngine;
+
+namespace Mirror.SimpleWeb
+{
+    internal interface IBufferOwner
+    {
+        void Return(ArrayBuffer buffer);
+    }
+
+    public struct ArrayBuffer : IDisposable
+    {
+        public readonly byte[] array;
+        private readonly IBufferOwner owner;
+
+        internal ArrayBuffer(IBufferOwner owner, int size)
+        {
+            this.owner = owner;
+            array = new byte[size];
+        }
+
+        public void Dispose()
+        {
+            owner.Return(this);
+        }
+    }
+
+    internal class BufferBucket : IBufferOwner
+    {
+        public readonly int arraySize;
+        readonly ConcurrentQueue<ArrayBuffer> buffers;
+
+        public BufferBucket(int arraySize)
+        {
+            this.arraySize = arraySize;
+            buffers = new ConcurrentQueue<ArrayBuffer>();
+        }
+
+        public ArrayBuffer Take()
+        {
+            return buffers.TryDequeue(out ArrayBuffer buffer) ? buffer : new ArrayBuffer(this, arraySize);
+        }
+        public void Return(ArrayBuffer buffer)
+        {
+            Debug.Assert(buffer.array.Length == arraySize, "Buffer that was returned had an array of the wrong size");
+            buffers.Enqueue(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Collection of different sized buffers 
+    /// </summary>
+    /// <remarks>
+    /// Problem:
+    /// * need cached byte[] so that new ones arn't created each time.
+    /// * arrays sent are multiple different sizes
+    /// * some message might be bit so need buffers to cover that size
+    /// * most messages will be small compared to max message size
+    /// Solution:
+    /// * create multiple groups of buffers covering the range of allowed sizes
+    /// * split range using math.log so that there are more size groups for small buffers
+    /// </remarks>
+    public class BufferPool
+    {
+        internal readonly BufferBucket[] buckets;
+        readonly int bucketCount;
+        readonly int smallest;
+        readonly int largest;
+
+        public BufferPool(int bucketCount, int smallest, int largest)
+        {
+            if (bucketCount < 2) throw new ArgumentException("Count must be atleast 2");
+            if (smallest < 1) throw new ArgumentException("Smallest must be atleast 1");
+            if (largest < smallest) throw new ArgumentException("Largest must be greater than smallest");
+
+
+            this.bucketCount = bucketCount;
+            this.smallest = smallest;
+            this.largest = largest;
+
+
+            // split range over log scale (more buckets for smaller sizes)
+
+            double minLog = Math.Log(this.smallest);
+            double maxLog = Math.Log(this.largest);
+
+            double range = maxLog - minLog;
+            double each = range / (bucketCount - 1);
+
+            double[] sizes = new double[bucketCount];
+
+            for (int i = 0; i < bucketCount; i++)
+            {
+                sizes[i] = smallest * Math.Pow(Math.E, each * i);
+            }
+
+            buckets = new BufferBucket[bucketCount];
+
+            for (int i = 0; i < bucketCount; i++)
+            {
+                buckets[i] = new BufferBucket((int)Math.Ceiling(sizes[i]));
+            }
+
+            // Example
+            // 5         count  
+            // 20        smallest
+            // 16400     largest
+
+            // 3.0       log 20
+            // 9.7       log 16400 
+
+            // 6.7       range 9.7 - 3
+            // 1.675     each  6.7 / (5-1)
+
+            // 20        e^ (3 + 1.675 * 0)
+            // 107       e^ (3 + 1.675 * 1)
+            // 572       e^ (3 + 1.675 * 2)
+            // 3056      e^ (3 + 1.675 * 3)
+            // 16,317    e^ (3 + 1.675 * 4)
+
+            // perceision wont be lose when using doubles
+        }
+
+        public ArrayBuffer Take(int size)
+        {
+            if (size > largest) { throw new ArgumentException($"Size ({size}) is greatest that largest ({largest})"); }
+
+            for (int i = 0; i < bucketCount; i++)
+            {
+                if (size < buckets[i].arraySize)
+                {
+                    return buckets[i].Take();
+                }
+            }
+
+            throw new ArgumentException($"Size ({size}) is greatest that largest ({largest})");
+        }
+    }
+}

--- a/source/Common/BufferPool.cs.meta
+++ b/source/Common/BufferPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94ae50f3ec35667469b861b12cd72f92
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/Common/Connection.cs
+++ b/source/Common/Connection.cs
@@ -21,7 +21,7 @@ namespace Mirror.SimpleWeb
         public Thread sendThread;
 
         public ManualResetEvent sendPending = new ManualResetEvent(false);
-        public ConcurrentQueue<ArraySegment<byte>> sendQueue = new ConcurrentQueue<ArraySegment<byte>>();
+        public ConcurrentQueue<ArrayBuffer> sendQueue = new ConcurrentQueue<ArrayBuffer>();
 
         public Connection(TcpClient client)
         {
@@ -54,6 +54,13 @@ namespace Mirror.SimpleWeb
                 stream = null;
                 client.Dispose();
                 client = null;
+
+                // Todo is this ok to run on the main thread?? will it have negative performance if queue is large
+                // release all buffers in send queue
+                while (sendQueue.TryDequeue(out ArrayBuffer buffer))
+                {
+                    buffer.Release();
+                }
 
                 return true;
             }

--- a/source/Common/ReadHelper.cs
+++ b/source/Common/ReadHelper.cs
@@ -10,9 +10,10 @@ namespace Mirror.SimpleWeb
 
     public static class ReadHelper
     {
+        /// <returns>outOffset + length</returns>
         /// <exception cref="ReadHelperException"></exception>
         /// <exception cref="IOException"></exception>
-        public static void Read(Stream stream, byte[] outBuffer, int outOffset, int length)
+        public static int Read(Stream stream, byte[] outBuffer, int outOffset, int length)
         {
             int received = 0;
             try
@@ -44,6 +45,8 @@ namespace Mirror.SimpleWeb
             {
                 throw new ReadHelperException("returned not equal to length");
             }
+
+            return outOffset + received;
         }
 
         public enum ReadResult

--- a/source/Common/ReceiveLoop.cs
+++ b/source/Common/ReceiveLoop.cs
@@ -12,17 +12,17 @@ namespace Mirror.SimpleWeb
     {
         public static void Loop(Connection conn, int maxMessageSize, bool expectMask, ConcurrentQueue<Message> queue, Action<Connection> closeCallback)
         {
+            byte[] readBuffer = new byte[Constants.HeaderSize + (expectMask ? Constants.MaskSize : 0) + maxMessageSize];
             try
             {
                 try
                 {
                     TcpClient client = conn.client;
                     Stream stream = conn.stream;
-                    byte[] headerBuffer = new byte[Constants.HeaderSize];
 
                     while (client.Connected)
                     {
-                        bool success = ReadOneMessage(queue, closeCallback, conn, stream, headerBuffer, maxMessageSize, expectMask);
+                        bool success = ReadOneMessage(queue, closeCallback, conn, stream, readBuffer, maxMessageSize, expectMask);
                         if (!success)
                             break;
                     }
@@ -58,39 +58,41 @@ namespace Mirror.SimpleWeb
             }
         }
 
-        static bool ReadOneMessage(ConcurrentQueue<Message> queue, Action<Connection> closeCallback, Connection conn, Stream stream, byte[] headerBuffer, int maxMessageSize, bool expectMask)
+        static bool ReadOneMessage(ConcurrentQueue<Message> queue, Action<Connection> closeCallback, Connection conn, Stream stream, byte[] buffer, int maxMessageSize, bool expectMask)
         {
+            int offset = 0;
             // read 2
-            ReadHelper.Read(stream, headerBuffer, 0, Constants.HeaderMinSize);
+            offset = ReadHelper.Read(stream, buffer, offset, Constants.HeaderMinSize);
 
-            if (MessageProcessor.NeedToReadShortLength(headerBuffer))
+
+            if (MessageProcessor.NeedToReadShortLength(buffer))
             {
-                ReadHelper.Read(stream, headerBuffer, Constants.HeaderMinSize, Constants.ShortLength);
+                offset = ReadHelper.Read(stream, buffer, offset, Constants.ShortLength);
             }
 
-            MessageProcessor.ValidateHeader(headerBuffer, maxMessageSize, expectMask);
-
-            byte[] maskBuffer = new byte[Constants.MaskSize];
-            if (expectMask)
-            {
-                ReadHelper.Read(stream, maskBuffer, 0, Constants.MaskSize);
-            }
-
-            int opcode = MessageProcessor.GetOpcode(headerBuffer);
-            int payloadLength = MessageProcessor.GetPayloadLength(headerBuffer);
-
-            byte[] payload = new byte[payloadLength];
-            ReadHelper.Read(stream, payload, 0, payloadLength);
+            MessageProcessor.ValidateHeader(buffer, maxMessageSize, expectMask);
 
             if (expectMask)
             {
-                MessageProcessor.ToggleMask(payload, 0, payloadLength, maskBuffer, 0);
+                offset = ReadHelper.Read(stream, buffer, offset, Constants.MaskSize);
+            }
+
+            int opcode = MessageProcessor.GetOpcode(buffer);
+            int payloadLength = MessageProcessor.GetPayloadLength(buffer);
+
+            offset = ReadHelper.Read(stream, buffer, offset, payloadLength);
+
+            int msgOffset = offset - payloadLength;
+            if (expectMask)
+            {
+                int maskOffset = offset - payloadLength - Constants.MaskSize;
+                MessageProcessor.ToggleMask(buffer, msgOffset, payloadLength, buffer, maskOffset);
             }
 
             // dump after mask off
-            Log.DumpBuffer($"Message From Client {conn}", payload, 0, payloadLength);
+            Log.DumpBuffer($"Message From Client {conn}", buffer, 0, payloadLength);
 
-            HandleMessage(queue, closeCallback, opcode, conn, payload, 0, payloadLength);
+            HandleMessage(queue, closeCallback, opcode, conn, buffer, msgOffset, payloadLength);
             return true;
         }
 
@@ -98,7 +100,12 @@ namespace Mirror.SimpleWeb
         {
             if (opcode == 2)
             {
-                ArraySegment<byte> data = new ArraySegment<byte>(buffer, offset, length);
+                // todo remove allocation
+                byte[] copy = new byte[length];
+
+                Array.Copy(buffer, offset, copy, 0, length);
+
+                ArraySegment<byte> data = new ArraySegment<byte>(buffer);
 
                 queue.Enqueue(new Message(conn.connId, data));
             }

--- a/source/Common/ReceiveLoop.cs
+++ b/source/Common/ReceiveLoop.cs
@@ -60,6 +60,7 @@ namespace Mirror.SimpleWeb
 
         static bool ReadOneMessage(ConcurrentQueue<Message> queue, Action<Connection> closeCallback, Connection conn, Stream stream, byte[] buffer, int maxMessageSize, bool expectMask)
         {
+            Log.Verbose($"Message From {conn}");
             int offset = 0;
             // read 2
             offset = ReadHelper.Read(stream, buffer, offset, Constants.HeaderMinSize);
@@ -69,6 +70,7 @@ namespace Mirror.SimpleWeb
             {
                 offset = ReadHelper.Read(stream, buffer, offset, Constants.ShortLength);
             }
+
 
             MessageProcessor.ValidateHeader(buffer, maxMessageSize, expectMask);
 
@@ -80,6 +82,8 @@ namespace Mirror.SimpleWeb
             int opcode = MessageProcessor.GetOpcode(buffer);
             int payloadLength = MessageProcessor.GetPayloadLength(buffer);
 
+            Log.Verbose($"Header ln:{payloadLength} op:{opcode} mask:{expectMask}");
+
             offset = ReadHelper.Read(stream, buffer, offset, payloadLength);
 
             int msgOffset = offset - payloadLength;
@@ -90,7 +94,8 @@ namespace Mirror.SimpleWeb
             }
 
             // dump after mask off
-            Log.DumpBuffer($"Message From Client {conn}", buffer, 0, payloadLength);
+            Log.DumpBuffer($"Raw Header", buffer, 0, msgOffset);
+            Log.DumpBuffer($"Message", buffer, msgOffset, payloadLength);
 
             HandleMessage(queue, closeCallback, opcode, conn, buffer, msgOffset, payloadLength);
             return true;

--- a/source/Common/ReceiveLoop.cs
+++ b/source/Common/ReceiveLoop.cs
@@ -110,7 +110,7 @@ namespace Mirror.SimpleWeb
 
                 Array.Copy(buffer, offset, copy, 0, length);
 
-                ArraySegment<byte> data = new ArraySegment<byte>(buffer);
+                ArraySegment<byte> data = new ArraySegment<byte>(copy);
 
                 queue.Enqueue(new Message(conn.connId, data));
             }

--- a/tests/Editor/BufferPoolTests.cs
+++ b/tests/Editor/BufferPoolTests.cs
@@ -76,12 +76,5 @@ namespace Mirror.SimpleWeb.Tests
             // largest can be 1 greater because caclatations should round up
             Assert.That(largestGroup.arraySize, Is.EqualTo(largest).Or.EqualTo(largest + 1), "largest should be equal to larget or large + 1");
         }
-
-
-        [Test]
-        public void dfdfdfdfdfdf()
-        {
-
-        }
     }
 }

--- a/tests/Editor/BufferPoolTests.cs
+++ b/tests/Editor/BufferPoolTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Mirror.SimpleWeb.Tests
+{
+    [Category("SimpleWebTransport")]
+    public class BufferPoolTests
+    {
+        [Test]
+        [TestCase(0)]
+        [TestCase(-10)]
+        public void ErrorWhenSmallestBelow1(int smallest)
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            {
+                BufferPool bufferPool = new BufferPool(5, smallest, 16384);
+            });
+
+            Assert.That(exception.Message, Is.EqualTo("Smallest must be atleast 1"));
+        }
+
+        [Test]
+        [TestCase(10, 1)]
+        [TestCase(100, 99)]
+        [TestCase(1, -1)]
+        [TestCase(1, 0)]
+        public void ErrorWhenLargestBelowSmallest(int smallest, int largest)
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            {
+                BufferPool bufferPool = new BufferPool(5, smallest, largest);
+            });
+
+            Assert.That(exception.Message, Is.EqualTo("Largest must be greater than smallest"));
+        }
+
+        [Test]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(-10)]
+        public void ErrorWhenCountIsBelow2(int count)
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            {
+                BufferPool bufferPool = new BufferPool(count, 2, 16384);
+            });
+
+            Assert.That(exception.Message, Is.EqualTo("Count must be atleast 2"));
+        }
+
+        static IEnumerable CreatesCorrectCountSource => Enumerable.Range(2, 100);
+        [Test]
+        [TestCaseSource(nameof(CreatesCorrectCountSource))]
+        public void CreatesCorrectCount(int count)
+        {
+            BufferPool bufferPool = new BufferPool(count, 2, 16384);
+
+            Assert.That(bufferPool.buckets.Length, Is.EqualTo(count));
+        }
+
+        [Test]
+        [TestCase(2, 2, 100)]
+        [TestCase(5, 2, 16384)]
+        [TestCase(8, 2, 16384)]
+        [TestCase(15, 2, 16384)]
+        [TestCase(15, 100, 200)]
+        public void SmallestAndLargestGroupsHavecorrectvalues(int count, int smallest, int largest)
+        {
+            BufferPool bufferPool = new BufferPool(count, smallest, largest);
+
+            BufferBucket smallestGroup = bufferPool.buckets[0];
+            BufferBucket largestGroup = bufferPool.buckets[count - 1];
+            Assert.That(smallestGroup.arraySize, Is.EqualTo(smallest));
+            // largest can be 1 greater because caclatations should round up
+            Assert.That(largestGroup.arraySize, Is.EqualTo(largest).Or.EqualTo(largest + 1), "largest should be equal to larget or large + 1");
+        }
+
+
+        [Test]
+        public void dfdfdfdfdfdf()
+        {
+
+        }
+    }
+}

--- a/tests/Editor/BufferPoolTests.cs.meta
+++ b/tests/Editor/BufferPoolTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9f64d29724a7b04e841abde7dd124da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/Runtime/Client/SimpleWebClientTestBase.cs
+++ b/tests/Runtime/Client/SimpleWebClientTestBase.cs
@@ -9,6 +9,7 @@ namespace Mirror.SimpleWeb.Tests.Client
     public abstract class SimpleWebClientTestBase
     {
         protected const int timeout = 4000;
+        const Log.Levels LogLevel = Log.Levels.info;
 
         protected abstract bool StartServer { get; }
 
@@ -91,11 +92,11 @@ namespace Mirror.SimpleWeb.Tests.Client
 
             SimpleWebTransport transport = go.AddComponent<SimpleWebTransport>();
             transport.port = 7776;
-            transport.logLevels = Log.Levels.info;
+            transport.logLevels = LogLevel;
             transport.receiveTimeout = timeout;
             transport.sendTimeout = timeout;
 
-            Log.level = Log.Levels.info;
+            Log.level = LogLevel;
             return transport;
         }
     }


### PR DESCRIPTION
Problem:
* need cached byte[] so that new ones arn't created each time.
* arrays sent are multiple different sizes
* some message might be bit so need buffers to cover that size
* most messages will be small compared to max message size

Solution:
* create multiple groups of buffers covering the range of allowed sizes
* split range using math.log so that there are more size groups for small buffers